### PR TITLE
feat: healed-serde

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -2,3 +2,4 @@
 
 # wasmコンポーネントを結合したバイナリ
 composed.wasm
+PLAN.md

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2402,6 +2402,15 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "5419bdc4f6a9207fbeba6d11b604d481addf78ecd10c11ad51e76c2f6482748d"
 
 [[package]]
+name = "healed-serde"
+version = "0.1.0"
+dependencies = [
+ "secded",
+ "serde",
+ "thiserror 2.0.17",
+]
+
+[[package]]
 name = "heck"
 version = "0.5.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -4390,6 +4399,16 @@ dependencies = [
  "memmap2",
  "smithay-client-toolkit 0.19.2",
  "tiny-skia",
+]
+
+[[package]]
+name = "secded"
+version = "1.1.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "50763bfbfb938531504a97aa359eca427bfe8f709eda7e1cd475ba3be549ed24"
+dependencies = [
+ "byteorder",
+ "lazy_static",
 ]
 
 [[package]]

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2433,6 +2433,7 @@ dependencies = [
  "crc",
  "secded",
  "serde",
+ "tempfile",
  "thiserror 2.0.17",
 ]
 

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -643,6 +643,15 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "72b3254f16251a8381aa12e40e3c4d2f0199f8c6508fbecb9d91f575e0fbb8c6"
 
 [[package]]
+name = "bincode"
+version = "1.3.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b1f45e9417d87227c7a56d22e471c6206462cba514c7590c09aff4cf6d1ddcad"
+dependencies = [
+ "serde",
+]
+
+[[package]]
 name = "bindgen"
 version = "0.72.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1360,6 +1369,21 @@ name = "cranelift-srcgen"
 version = "0.120.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "02e3f4d783a55c64266d17dc67d2708852235732a100fc40dd9f1051adc64d7b"
+
+[[package]]
+name = "crc"
+version = "3.4.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "5eb8a2a1cd12ab0d987a5d5e825195d372001a4094a0376319d5a0ad71c1ba0d"
+dependencies = [
+ "crc-catalog",
+]
+
+[[package]]
+name = "crc-catalog"
+version = "2.4.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "19d374276b40fb8bbdee95aef7c7fa6b5316ec764510eb64b8dd0e2ed0d7e7f5"
 
 [[package]]
 name = "crc32fast"
@@ -2405,6 +2429,8 @@ checksum = "5419bdc4f6a9207fbeba6d11b604d481addf78ecd10c11ad51e76c2f6482748d"
 name = "healed-serde"
 version = "0.1.0"
 dependencies = [
+ "bincode",
+ "crc",
  "secded",
  "serde",
  "thiserror 2.0.17",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2431,8 +2431,10 @@ version = "0.1.0"
 dependencies = [
  "bincode",
  "crc",
+ "criterion",
  "secded",
  "serde",
+ "serde_json",
  "tempfile",
  "thiserror 2.0.17",
 ]

--- a/crates/healed-serde/Cargo.toml
+++ b/crates/healed-serde/Cargo.toml
@@ -1,0 +1,9 @@
+[package]
+name = "healed-serde"
+version = "0.1.0"
+edition = "2021"
+
+[dependencies]
+secded = "1.1.0"
+thiserror = "2.0"
+serde = { version = "1.0", features = ["derive"] }

--- a/crates/healed-serde/Cargo.toml
+++ b/crates/healed-serde/Cargo.toml
@@ -12,3 +12,9 @@ bincode = "1.3.3"
 
 [dev-dependencies]
 tempfile = "3"
+serde_json = "1.0"
+criterion.workspace = true
+
+[[bench]]
+name = "json_serialize_bench"
+harness = false

--- a/crates/healed-serde/Cargo.toml
+++ b/crates/healed-serde/Cargo.toml
@@ -7,3 +7,5 @@ edition = "2021"
 secded = "1.1.0"
 thiserror = "2.0"
 serde = { version = "1.0", features = ["derive"] }
+crc = "3.4.0"
+bincode = "1.3.3"

--- a/crates/healed-serde/Cargo.toml
+++ b/crates/healed-serde/Cargo.toml
@@ -9,3 +9,6 @@ thiserror = "2.0"
 serde = { version = "1.0", features = ["derive"] }
 crc = "3.4.0"
 bincode = "1.3.3"
+
+[dev-dependencies]
+tempfile = "3"

--- a/crates/healed-serde/Makefile
+++ b/crates/healed-serde/Makefile
@@ -1,0 +1,16 @@
+.PHONY: bench-json-baseline-save bench-json-baseline-compare bench-json-baseline-refresh
+
+# baseline名は固定運用
+BASELINE_NAME := healed-serde-json-baseline
+SAMPLE_SIZE ?= 30
+
+# 現在実装をbaselineとして保存
+bench-json-baseline-save:
+	cargo bench -p healed-serde --bench json_serialize_bench -- --save-baseline $(BASELINE_NAME) --sample-size $(SAMPLE_SIZE)
+
+# 固定baselineとの差分を計測
+bench-json-baseline-compare:
+	cargo bench -p healed-serde --bench json_serialize_bench -- --baseline $(BASELINE_NAME) --sample-size $(SAMPLE_SIZE)
+
+# baselineの更新（保存→比較）
+bench-json-baseline-refresh: bench-json-baseline-save bench-json-baseline-compare

--- a/crates/healed-serde/README.md
+++ b/crates/healed-serde/README.md
@@ -1,0 +1,76 @@
+# healed-serde
+
+堅牢なIoT向け永続化ライブラリ
+
+## 概要
+
+`healed-serde` は、ビット腐敗（ビット反転）や書き込み中の電源断が発生しやすい環境（IoTデバイスなど）において、データを安全に保存・復元するためのRustライブラリです。
+
+## 主な機能
+
+*   **自動修復**: SECDED（Single Error Correction, Double Error Detection）ハミング符号を用いて、1ビットのエラーを自動的に訂正し、2ビットのエラーを検出します。
+*   **電源断保護**: 3つのファイルスロットを使用したローリングアップデート戦略により、書き込み中の電源断によるデータ破損を防ぎます。常に最新の健全なデータを読み込みます。
+*   **整合性チェック**: CRC32によるデータ整合性の検証を行います。
+*   **柔軟な保護レベル**: データの重要度やサイズに応じて、保護レベル（オーバーヘッドと保護性能のトレードオフ）を選択可能です。
+
+## 使用方法
+
+`ReliableVault` 構造体を使用してデータの保存と読み込みを行います。保存対象のデータ構造体は `serde::Serialize` および `serde::Deserialize` を実装している必要があります。
+
+```rust
+use healed_serde::vault::ReliableVault;
+use healed_serde::ProtectionLevel;
+use serde::{Serialize, Deserialize};
+
+#[derive(Serialize, Deserialize, Debug, PartialEq)]
+struct DeviceConfig {
+    id: u32,
+    name: String,
+    settings: Vec<u8>,
+}
+
+fn main() -> Result<(), Box<dyn std::error::Error>> {
+    // 保存先ディレクトリとファイル名のベースを指定
+    // 例: ./data/device_config.0, ./data/device_config.1, ...
+    let vault = ReliableVault::new("./data", "device_config");
+
+    let config = DeviceConfig {
+        id: 12345,
+        name: "sensor-node-01".to_string(),
+        settings: vec![0x01, 0x02, 0x03],
+    };
+
+    // データを保存 (ProtectionLevel::Medium はバランス型)
+    vault.save(&config, ProtectionLevel::Medium)?;
+
+    // データを読み込み
+    // 破損がある場合は自動的に修復、または過去の健全なバックアップから復元されます
+    let loaded_config: DeviceConfig = vault.load()?;
+
+    println!("Loaded: {:?}", loaded_config);
+    Ok(())
+}
+```
+
+## 保護レベル (ProtectionLevel)
+
+*   `High`: 8bitデータごとにECCを付与。オーバーヘッド大、保護性能高。
+*   `Medium`: 32bitデータごとにECCを付与。バランス型。
+*   `Low`: 64bitデータごとにECCを付与。オーバーヘッド小。
+
+## ファイル構成とローリング戦略
+
+`ReliableVault` は、データの整合性を保つために3つのファイルスロットを使用します。
+
+*   **ファイル名**: 指定されたベース名に `.0`, `.1`, `.2` のサフィックスが付与されます（例: `data.0`, `data.1`, `data.2`）。
+*   **書き込み**: 常に最も古いシーケンス番号を持つスロット（または未作成のスロット）を上書きします。これにより、書き込み中に電源断が発生しても、他の2つのスロットには過去の有効なデータが残ります。
+*   **読み込み**: 全てのスロットをスキャンし、破損していないデータの中で最も新しいシーケンス番号を持つものを自動的に選択します。
+
+### ファイルフォーマット
+
+各ファイルは以下の構造を持つバイナリ形式で保存されます。
+
+1.  **Primary Header (16 bytes)**: メタデータ（シーケンス番号、保護レベル、ペイロード長）。SECDEDで保護されており、1ビットエラーを自動修復可能。
+2.  **Secondary Header (16 bytes)**: Primary Headerのバックアップコピー。
+3.  **Payload**: ユーザーデータ。指定された `ProtectionLevel` に基づいてブロック分割され、ECCエンコードされています。
+4.  **Footer (8 bytes)**: 全体のCRC32チェックサムとシーケンス番号の検証用データ。

--- a/crates/healed-serde/README.md
+++ b/crates/healed-serde/README.md
@@ -12,6 +12,7 @@
 *   **電源断保護**: 3つのファイルスロットを使用したローリングアップデート戦略により、書き込み中の電源断によるデータ破損を防ぎます。常に最新の健全なデータを読み込みます。
 *   **整合性チェック**: CRC32によるデータ整合性の検証を行います。
 *   **柔軟な保護レベル**: データの重要度やサイズに応じて、保護レベル（オーバーヘッドと保護性能のトレードオフ）を選択可能です。
+*   **抽象化されたストレージ**: `StorageBackend` トレイトを実装することで、ファイルシステム以外のバックエンド（KVS、mmapなど）にも対応可能です。
 
 ## 使用方法
 
@@ -32,7 +33,7 @@ struct DeviceConfig {
 fn main() -> Result<(), Box<dyn std::error::Error>> {
     // 保存先ディレクトリとファイル名のベースを指定
     // 例: ./data/device_config.0, ./data/device_config.1, ...
-    let vault = ReliableVault::new("./data", "device_config");
+    let vault = ReliableVault::new_with_fs("./data", "device_config");
 
     let config = DeviceConfig {
         id: 12345,

--- a/crates/healed-serde/benches/json_serialize_bench.rs
+++ b/crates/healed-serde/benches/json_serialize_bench.rs
@@ -1,0 +1,85 @@
+use criterion::{black_box, criterion_group, criterion_main, BenchmarkId, Criterion, Throughput};
+use serde::{Deserialize, Serialize};
+
+#[derive(Debug, Clone, Serialize, Deserialize)]
+struct JsonBenchRecord {
+    id: u64,
+    name: String,
+    tags: Vec<String>,
+    values: Vec<u64>,
+    payload: String,
+}
+
+#[derive(Debug, Clone, Serialize, Deserialize)]
+struct JsonBenchDataset {
+    version: u32,
+    records: Vec<JsonBenchRecord>,
+}
+
+fn build_dataset(record_count: usize, payload_len: usize) -> JsonBenchDataset {
+    let mut records = Vec::with_capacity(record_count);
+    for i in 0..record_count {
+        records.push(JsonBenchRecord {
+            id: i as u64,
+            name: format!("record-{i}"),
+            tags: (0..6).map(|j| format!("tag-{i}-{j}")).collect(),
+            values: (0..32).map(|j| (i as u64 + j as u64) * 17).collect(),
+            payload: "x".repeat(payload_len),
+        });
+    }
+
+    JsonBenchDataset {
+        version: 1,
+        records,
+    }
+}
+
+fn benchmark_json_serialize(c: &mut Criterion) {
+    let mut group = c.benchmark_group("json_serialize");
+    let cases = [
+        ("small", 32usize, 128usize),
+        ("medium", 256usize, 512usize),
+        ("large", 1024usize, 2048usize),
+    ];
+
+    for (name, record_count, payload_len) in cases {
+        let dataset = build_dataset(record_count, payload_len);
+        let encoded = serde_json::to_vec(&dataset).expect("failed to pre-serialize benchmark data");
+
+        group.throughput(Throughput::Bytes(encoded.len() as u64));
+
+        group.bench_with_input(BenchmarkId::new("to_vec", name), &dataset, |b, dataset| {
+            b.iter(|| serde_json::to_vec(black_box(dataset)).expect("serialize failed"))
+        });
+
+        group.bench_with_input(
+            BenchmarkId::new("from_slice", name),
+            &encoded,
+            |b, encoded| {
+                b.iter(|| {
+                    let decoded: JsonBenchDataset =
+                        serde_json::from_slice(black_box(encoded)).expect("deserialize failed");
+                    black_box(decoded)
+                })
+            },
+        );
+
+        group.bench_with_input(
+            BenchmarkId::new("roundtrip", name),
+            &dataset,
+            |b, dataset| {
+                b.iter(|| {
+                    let encoded = serde_json::to_vec(black_box(dataset)).expect("serialize failed");
+                    let decoded: JsonBenchDataset =
+                        serde_json::from_slice(black_box(&encoded)).expect("deserialize failed");
+                    black_box(decoded)
+                })
+            },
+        );
+    }
+
+    group.finish();
+}
+
+criterion_group!(benches, benchmark_json_serialize);
+criterion_main!(benches);

--- a/crates/healed-serde/benches/json_serialize_bench.rs
+++ b/crates/healed-serde/benches/json_serialize_bench.rs
@@ -1,6 +1,14 @@
+//! `serde_json` を使用したシリアライズ/デシリアライズのパフォーマンスベンチマーク。
+//!
+//! このベンチマークは、`healed-serde` 自体の機能ではなく、
+//! 比較対象として一般的なJSONシリアライズの性能を測定するために用意されています。
+//! データセットのサイズ（small, medium, large）ごとに、
+//! シリアライズ、デシリアライズ、およびその両方の処理時間を計測します。
+
 use criterion::{black_box, criterion_group, criterion_main, BenchmarkId, Criterion, Throughput};
 use serde::{Deserialize, Serialize};
 
+/// ベンチマーク用のJSONレコード。
 #[derive(Debug, Clone, Serialize, Deserialize)]
 struct JsonBenchRecord {
     id: u64,
@@ -10,12 +18,14 @@ struct JsonBenchRecord {
     payload: String,
 }
 
+/// ベンチマーク用のJSONデータセット。複数のレコードを含む。
 #[derive(Debug, Clone, Serialize, Deserialize)]
 struct JsonBenchDataset {
     version: u32,
     records: Vec<JsonBenchRecord>,
 }
 
+/// 指定されたレコード数とペイロードサイズでテスト用のデータセットを構築する。
 fn build_dataset(record_count: usize, payload_len: usize) -> JsonBenchDataset {
     let mut records = Vec::with_capacity(record_count);
     for i in 0..record_count {
@@ -34,6 +44,12 @@ fn build_dataset(record_count: usize, payload_len: usize) -> JsonBenchDataset {
     }
 }
 
+/// `serde_json` を使用したシリアライズ/デシリアライズのパフォーマンスを測定するベンチマーク。
+///
+/// 以下の3つのシナリオを、データサイズを変えながら（small, medium, large）テストする:
+/// - `to_vec`: オブジェクトからJSONバイト列へのシリアライズ。
+/// - `from_slice`: JSONバイト列からオブジェクトへのデシリアライズ。
+/// - `roundtrip`: シリアライズとデシリアライズの両方。
 fn benchmark_json_serialize(c: &mut Criterion) {
     let mut group = c.benchmark_group("json_serialize");
     let cases = [

--- a/crates/healed-serde/src/ecc.rs
+++ b/crates/healed-serde/src/ecc.rs
@@ -52,7 +52,7 @@ pub fn encode(data: &[u8], level: ProtectionLevel) -> Result<Vec<EncodedBlock>, 
         }
         ProtectionLevel::Medium => {
             // 32bit (4 bytes) chunks
-            if data.len() % 4 != 0 {
+            if !data.len().is_multiple_of(4) {
                 return Err(EccError::InvalidLength);
             }
             let secded = SecDed64::new(57);
@@ -69,7 +69,7 @@ pub fn encode(data: &[u8], level: ProtectionLevel) -> Result<Vec<EncodedBlock>, 
         }
         ProtectionLevel::Low => {
             // 64bit (8 bytes) chunks
-            if data.len() % 8 != 0 {
+            if !data.len().is_multiple_of(8) {
                 return Err(EccError::InvalidLength);
             }
             let secded = SecDed128::new(120);
@@ -168,6 +168,7 @@ pub fn decode(blocks: &[EncodedBlock]) -> Result<Vec<u8>, EccError> {
 mod tests {
     use super::*;
 
+    /// High保護レベルでエンコード/デコードの往復が成立することを検証。
     #[test]
     fn test_roundtrip_high() {
         let data = b"hello world";
@@ -177,6 +178,7 @@ mod tests {
         assert_eq!(data, decoded.as_slice());
     }
 
+    /// Medium保護レベルでエンコード/デコードの往復が成立することを検証。
     #[test]
     fn test_roundtrip_medium() {
         let data = b"hello world!"; // 12 bytes, multiple of 4
@@ -186,6 +188,7 @@ mod tests {
         assert_eq!(data, decoded.as_slice());
     }
 
+    /// Low保護レベルでエンコード/デコードの往復が成立することを検証。
     #[test]
     fn test_roundtrip_low() {
         let data = b"16 bytes data..."; // 16 bytes, multiple of 8
@@ -195,6 +198,7 @@ mod tests {
         assert_eq!(data, decoded.as_slice());
     }
 
+    /// High保護レベルで1ビット破損が訂正復元されることを検証。
     #[test]
     fn test_1bit_flip_correction_high() {
         let data = b"A";
@@ -210,6 +214,7 @@ mod tests {
         assert_eq!(data, decoded.as_slice(), "Data should be corrected");
     }
 
+    /// High保護レベルで2ビット破損が Uncorrectable になることを検証。
     #[test]
     fn test_2bit_flip_uncorrectable_high() {
         let data = b"B";
@@ -225,6 +230,7 @@ mod tests {
         assert!(matches!(result, Err(EccError::Uncorrectable)));
     }
 
+    /// Medium/Low保護レベルで不正な入力長に InvalidLength が返ることを検証。
     #[test]
     fn test_invalid_length_error() {
         let data = b"12345"; // 5 bytes

--- a/crates/healed-serde/src/ecc.rs
+++ b/crates/healed-serde/src/ecc.rs
@@ -1,17 +1,7 @@
+use crate::ProtectionLevel;
 use secded::{secded7264, SecDed128, SecDed64, SecDedCodec};
 use serde::{Deserialize, Serialize};
 use thiserror::Error;
-
-/// データ保護レベル。オーバーヘッドと保護性能のトレードオフを調整します。
-#[derive(Debug, Clone, Copy, PartialEq, Eq, Serialize, Deserialize)]
-pub enum ProtectionLevel {
-    /// 8bitデータごとにECCを付与します (高密度保護)。
-    High,
-    /// 32bitデータごとにECCを付与します (バランス)。
-    Medium,
-    /// 64bitデータごとにECCを付与します (低オーバーヘッド)。
-    Low,
-}
 
 /// ECCでエンコードされたデータブロック。
 /// ProtectionLevelに応じて内部のデータサイズが変わります。

--- a/crates/healed-serde/src/ecc.rs
+++ b/crates/healed-serde/src/ecc.rs
@@ -1,0 +1,247 @@
+use secded::{secded7264, SecDed128, SecDed64, SecDedCodec};
+use serde::{Deserialize, Serialize};
+use thiserror::Error;
+
+/// データ保護レベル。オーバーヘッドと保護性能のトレードオフを調整します。
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Serialize, Deserialize)]
+pub enum ProtectionLevel {
+    /// 8bitデータごとにECCを付与します (高密度保護)。
+    High,
+    /// 32bitデータごとにECCを付与します (バランス)。
+    Medium,
+    /// 64bitデータごとにECCを付与します (低オーバーヘッド)。
+    Low,
+}
+
+/// ECCでエンコードされたデータブロック。
+/// ProtectionLevelに応じて内部のデータサイズが変わります。
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Serialize, Deserialize)]
+pub enum EncodedBlock {
+    High(u16),
+    Medium(u64),
+    Low(u128),
+}
+
+/// ECC処理におけるエラー。
+#[derive(Error, Debug, PartialEq, Eq)]
+pub enum EccError {
+    /// デコード対象のブロック間でProtectionLevelが一致しません。
+    #[error("Inconsistent protection level in encoded blocks")]
+    InconsistentLevel,
+    /// 修正不可能なデータ破損が検出されました (2ビット以上のエラー)。
+    #[error("Uncorrectable data corruption detected")]
+    Uncorrectable,
+    /// 指定されたProtectionLevelに対して、入力データの長さが不正です。
+    #[error("Invalid input data length for the protection level")]
+    InvalidLength,
+}
+
+/// 生データを指定された保護レベルでエンコードし、`EncodedBlock`のベクタを返します。
+///
+/// # Arguments
+///
+/// * `data` - エンコードするバイトスライス。
+/// * `level` - 使用する保護レベル。
+///
+/// # Errors
+///
+/// `EccError::InvalidLength` - `data`の長さが保護レベルの要求するブロックサイズの倍数でない場合。
+pub fn encode(data: &[u8], level: ProtectionLevel) -> Result<Vec<EncodedBlock>, EccError> {
+    match level {
+        ProtectionLevel::High => {
+            // 8bit (1 byte) chunks
+            Ok(data
+                .iter()
+                .map(|&byte| {
+                    let mut raw = [0u8; 8];
+                    raw[0] = byte;
+                    let parity = secded7264::encode(raw);
+                    EncodedBlock::High(u16::from_le_bytes([byte, parity]))
+                })
+                .collect())
+        }
+        ProtectionLevel::Medium => {
+            // 32bit (4 bytes) chunks
+            if data.len() % 4 != 0 {
+                return Err(EccError::InvalidLength);
+            }
+            let secded = SecDed64::new(57);
+            Ok(data
+                .chunks_exact(4)
+                .map(|chunk| {
+                    let mut raw = [0u8; 4];
+                    raw.copy_from_slice(chunk);
+                    let mut encoded = ((u32::from_be_bytes(raw) as u64) << 32).to_be_bytes();
+                    secded.encode(&mut encoded);
+                    EncodedBlock::Medium(u64::from_be_bytes(encoded))
+                })
+                .collect())
+        }
+        ProtectionLevel::Low => {
+            // 64bit (8 bytes) chunks
+            if data.len() % 8 != 0 {
+                return Err(EccError::InvalidLength);
+            }
+            let secded = SecDed128::new(120);
+            Ok(data
+                .chunks_exact(8)
+                .map(|chunk| {
+                    let mut raw = [0u8; 8];
+                    raw.copy_from_slice(chunk);
+                    let mut encoded = ((u64::from_be_bytes(raw) as u128) << 64).to_be_bytes();
+                    secded.encode(&mut encoded);
+                    EncodedBlock::Low(u128::from_be_bytes(encoded))
+                })
+                .collect())
+        }
+    }
+}
+
+/// `EncodedBlock`のベクタをデコードし、元のデータを復元します。
+/// 1ビットのエラーは自動的に修復されます。
+///
+/// # Arguments
+///
+/// * `blocks` - デコードする`EncodedBlock`のスライス。
+///
+/// # Errors
+///
+/// * `EccError::InconsistentLevel` - スライス内に異なる保護レベルのブロックが混在している場合。
+/// * `EccError::Uncorrectable` - 2ビット以上の修復不可能なエラーが検出された場合。
+pub fn decode(blocks: &[EncodedBlock]) -> Result<Vec<u8>, EccError> {
+    if blocks.is_empty() {
+        return Ok(Vec::new());
+    }
+
+    let mut decoded_data = Vec::new();
+
+    // 最初のブロックからレベルを判断し、全ブロックで一貫しているか検証
+    let level = match blocks[0] {
+        EncodedBlock::High(_) => ProtectionLevel::High,
+        EncodedBlock::Medium(_) => ProtectionLevel::Medium,
+        EncodedBlock::Low(_) => ProtectionLevel::Low,
+    };
+
+    match level {
+        ProtectionLevel::High => {
+            for block in blocks {
+                let EncodedBlock::High(encoded) = *block else {
+                    return Err(EccError::InconsistentLevel);
+                };
+
+                let [data, parity] = encoded.to_le_bytes();
+                let mut decoded = [0u8; 8];
+                decoded[0] = data;
+                if secded7264::decode(&mut decoded, parity).is_err() {
+                    return Err(EccError::Uncorrectable);
+                }
+                decoded_data.push(decoded[0]);
+            }
+        }
+        ProtectionLevel::Medium => {
+            let secded = SecDed64::new(57);
+            for block in blocks {
+                let EncodedBlock::Medium(encoded) = *block else {
+                    return Err(EccError::InconsistentLevel);
+                };
+
+                let mut decoded = encoded.to_be_bytes();
+                if secded.decode(&mut decoded).is_err() {
+                    return Err(EccError::Uncorrectable);
+                }
+                decoded_data
+                    .extend_from_slice(&((u64::from_be_bytes(decoded) >> 32) as u32).to_be_bytes());
+            }
+        }
+        ProtectionLevel::Low => {
+            let secded = SecDed128::new(120);
+            for block in blocks {
+                let EncodedBlock::Low(encoded) = *block else {
+                    return Err(EccError::InconsistentLevel);
+                };
+
+                let mut decoded = encoded.to_be_bytes();
+                if secded.decode(&mut decoded).is_err() {
+                    return Err(EccError::Uncorrectable);
+                }
+                decoded_data.extend_from_slice(
+                    &((u128::from_be_bytes(decoded) >> 64) as u64).to_be_bytes(),
+                );
+            }
+        }
+    }
+
+    Ok(decoded_data)
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn test_roundtrip_high() {
+        let data = b"hello world";
+        let level = ProtectionLevel::High;
+        let encoded = encode(data, level).unwrap();
+        let decoded = decode(&encoded).unwrap();
+        assert_eq!(data, decoded.as_slice());
+    }
+
+    #[test]
+    fn test_roundtrip_medium() {
+        let data = b"hello world!"; // 12 bytes, multiple of 4
+        let level = ProtectionLevel::Medium;
+        let encoded = encode(data, level).unwrap();
+        let decoded = decode(&encoded).unwrap();
+        assert_eq!(data, decoded.as_slice());
+    }
+
+    #[test]
+    fn test_roundtrip_low() {
+        let data = b"16 bytes data..."; // 16 bytes, multiple of 8
+        let level = ProtectionLevel::Low;
+        let encoded = encode(data, level).unwrap();
+        let decoded = decode(&encoded).unwrap();
+        assert_eq!(data, decoded.as_slice());
+    }
+
+    #[test]
+    fn test_1bit_flip_correction_high() {
+        let data = b"A";
+        let level = ProtectionLevel::High;
+        let mut encoded = encode(data, level).unwrap();
+
+        // Flip 1 bit in the encoded data
+        if let EncodedBlock::High(ref mut val) = &mut encoded[0] {
+            *val ^= 1 << 5; // Flip 5th bit
+        }
+
+        let decoded = decode(&encoded).unwrap();
+        assert_eq!(data, decoded.as_slice(), "Data should be corrected");
+    }
+
+    #[test]
+    fn test_2bit_flip_uncorrectable_high() {
+        let data = b"B";
+        let level = ProtectionLevel::High;
+        let mut encoded = encode(data, level).unwrap();
+
+        if let EncodedBlock::High(ref mut val) = &mut encoded[0] {
+            *val ^= 1 << 3; // Flip bit 3
+            *val ^= 1 << 6; // Flip bit 6
+        }
+
+        let result = decode(&encoded);
+        assert!(matches!(result, Err(EccError::Uncorrectable)));
+    }
+
+    #[test]
+    fn test_invalid_length_error() {
+        let data = b"12345"; // 5 bytes
+        let result_medium = encode(data, ProtectionLevel::Medium);
+        assert_eq!(result_medium, Err(EccError::InvalidLength));
+
+        let result_low = encode(data, ProtectionLevel::Low);
+        assert_eq!(result_low, Err(EccError::InvalidLength));
+    }
+}

--- a/crates/healed-serde/src/error.rs
+++ b/crates/healed-serde/src/error.rs
@@ -1,0 +1,10 @@
+/// ライブラリ全体で使用されるエラー型。
+#[derive(Debug, thiserror::Error)]
+pub enum Error {
+    #[error("Invalid protection level value")]
+    InvalidProtectionLevel,
+
+    // 今後、I/Oエラーやシリアライズエラーなどを追加
+    #[error(transparent)]
+    Io(#[from] std::io::Error),
+}

--- a/crates/healed-serde/src/error.rs
+++ b/crates/healed-serde/src/error.rs
@@ -1,10 +1,29 @@
+use crate::ecc::EccError;
+
 /// ライブラリ全体で使用されるエラー型。
 #[derive(Debug, thiserror::Error)]
 pub enum Error {
     #[error("Invalid protection level value")]
     InvalidProtectionLevel,
 
-    // 今後、I/Oエラーやシリアライズエラーなどを追加
+    #[error("Frame data is too short to be valid")]
+    FrameTooShort,
+
+    #[error("Failed to recover header from both primary and secondary copies")]
+    UnrecoverableHeader,
+
+    #[error("Frame CRC check failed")]
+    CrcMismatch,
+
+    #[error("Invalid frame payload format")]
+    InvalidFrameFormat,
+
+    #[error("ECC error: {0}")]
+    Ecc(#[from] EccError),
+
+    #[error("Serialization/deserialization error: {0}")]
+    Bincode(#[from] Box<bincode::ErrorKind>),
+
     #[error(transparent)]
     Io(#[from] std::io::Error),
 }

--- a/crates/healed-serde/src/frame.rs
+++ b/crates/healed-serde/src/frame.rs
@@ -257,6 +257,7 @@ impl StorageFrame {
 mod tests {
     use super::*;
 
+    /// StorageFrameのシリアライズ/復元が無損失で往復できることを検証。
     #[test]
     fn test_frame_roundtrip() {
         let payload = b"hello, robust world!".to_vec();
@@ -267,6 +268,7 @@ mod tests {
         assert_eq!(frame, recovered_frame);
     }
 
+    /// Primaryヘッダーが壊れてもSecondaryヘッダーから復元できることを検証。
     #[test]
     fn test_recover_with_primary_header_corruption() {
         let payload = b"some important data".to_vec();
@@ -280,6 +282,7 @@ mod tests {
         assert_eq!(frame, recovered_frame);
     }
 
+    /// ペイロード領域の1ビット破損がECC復元後に元データへ戻ることを検証。
     #[test]
     fn test_recover_with_payload_corruption() {
         let payload: Vec<u8> = (0..128).collect();
@@ -295,6 +298,7 @@ mod tests {
         assert_eq!(frame, recovered_frame);
     }
 
+    /// フッターCRC改ざん時に CrcMismatch が返ることを検証。
     #[test]
     fn test_crc_mismatch_detection() {
         let payload = b"data that must be integral".to_vec();
@@ -311,6 +315,7 @@ mod tests {
         assert!(matches!(result, Err(Error::CrcMismatch)));
     }
 
+    /// Primary/Secondary両ヘッダー破損時に UnrecoverableHeader となることを検証。
     #[test]
     fn test_unrecoverable_header_error() {
         let payload = b"test".to_vec();
@@ -327,6 +332,7 @@ mod tests {
         assert!(matches!(result, Err(Error::UnrecoverableHeader)));
     }
 
+    /// 保護レベルごとのパディングサイズ規則が正しいことを検証。
     #[test]
     fn test_padding_logic() {
         // Medium (4-byte alignment)

--- a/crates/healed-serde/src/frame.rs
+++ b/crates/healed-serde/src/frame.rs
@@ -1,0 +1,350 @@
+use crate::ecc::{self, EncodedBlock};
+use crate::error::Error;
+use crate::metadata::{MetaData, MetaDataHeader};
+use crate::ProtectionLevel;
+use crc::{Crc, CRC_32_ISCSI};
+
+const PRIMARY_HEADER_OFFSET: usize = 0;
+const PRIMARY_HEADER_SIZE: usize = 16;
+const SECONDARY_HEADER_OFFSET: usize = PRIMARY_HEADER_OFFSET + PRIMARY_HEADER_SIZE;
+const SECONDARY_HEADER_SIZE: usize = 16;
+const HEADERS_SIZE: usize = PRIMARY_HEADER_SIZE + SECONDARY_HEADER_SIZE;
+const FOOTER_SIZE: usize = 8;
+const MIN_FRAME_SIZE: usize = HEADERS_SIZE + FOOTER_SIZE;
+
+pub const CRC_ISCSI: Crc<u32> = Crc::<u32>::new(&CRC_32_ISCSI);
+
+/// 8バイトのフッター。CRC32とシーケンス番号のチェックサムを含む。
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+struct Footer {
+    crc32: u32,
+    sequence_check: u32,
+}
+
+impl Footer {
+    fn new(crc32: u32, sequence: u64) -> Self {
+        Self {
+            crc32,
+            // u64のシーケンス番号をu32にキャストして格納。
+            // 完全な一致性検証ではないが、破損検出の一助となる。
+            sequence_check: sequence as u32,
+        }
+    }
+
+    fn to_bytes(self) -> [u8; FOOTER_SIZE] {
+        let mut bytes = [0u8; FOOTER_SIZE];
+        bytes[0..4].copy_from_slice(&self.crc32.to_le_bytes());
+        bytes[4..8].copy_from_slice(&self.sequence_check.to_le_bytes());
+        bytes
+    }
+
+    fn from_bytes(bytes: &[u8; FOOTER_SIZE]) -> Self {
+        let crc32 = u32::from_le_bytes(bytes[0..4].try_into().unwrap());
+        let sequence_check = u32::from_le_bytes(bytes[4..8].try_into().unwrap());
+        Self {
+            crc32,
+            sequence_check,
+        }
+    }
+}
+
+/// 永続化されるデータの完全なフレーム。
+/// ヘッダー、ペイロード、フッターで構成される。
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub struct StorageFrame {
+    pub meta: MetaData,
+    /// 元の（デコードされた）ペイロードデータ。
+    pub payload: Vec<u8>,
+}
+
+impl StorageFrame {
+    fn checksum_content(meta: &MetaData, payload: &[u8]) -> u32 {
+        let mut checksum_data = Vec::with_capacity(13 + payload.len());
+        checksum_data.extend_from_slice(&meta.sequence.to_le_bytes());
+        checksum_data.push(meta.level as u8);
+        checksum_data.extend_from_slice(&meta.payload_len.to_le_bytes());
+        checksum_data.extend_from_slice(payload);
+        CRC_ISCSI.checksum(&checksum_data)
+    }
+
+    fn payload_block_size(level: ProtectionLevel) -> usize {
+        match level {
+            ProtectionLevel::High => 1,
+            ProtectionLevel::Medium => 4,
+            ProtectionLevel::Low => 8,
+        }
+    }
+
+    fn encoded_block_size(level: ProtectionLevel) -> usize {
+        match level {
+            ProtectionLevel::High => 2,
+            ProtectionLevel::Medium => 8,
+            ProtectionLevel::Low => 16,
+        }
+    }
+
+    fn padded_len(payload_len: usize, level: ProtectionLevel) -> usize {
+        let block_size = Self::payload_block_size(level);
+        let remainder = payload_len % block_size;
+        if remainder == 0 {
+            payload_len
+        } else {
+            payload_len + (block_size - remainder)
+        }
+    }
+
+    fn encode_blocks_to_bytes(
+        blocks: &[EncodedBlock],
+        level: ProtectionLevel,
+    ) -> Result<Vec<u8>, Error> {
+        let mut bytes = Vec::with_capacity(blocks.len() * Self::encoded_block_size(level));
+
+        for block in blocks {
+            match (level, block) {
+                (ProtectionLevel::High, EncodedBlock::High(v)) => {
+                    bytes.extend_from_slice(&v.to_le_bytes())
+                }
+                (ProtectionLevel::Medium, EncodedBlock::Medium(v)) => {
+                    bytes.extend_from_slice(&v.to_le_bytes())
+                }
+                (ProtectionLevel::Low, EncodedBlock::Low(v)) => {
+                    bytes.extend_from_slice(&v.to_le_bytes())
+                }
+                _ => return Err(Error::InvalidFrameFormat),
+            }
+        }
+
+        Ok(bytes)
+    }
+
+    fn decode_blocks_from_bytes(
+        bytes: &[u8],
+        level: ProtectionLevel,
+        payload_len: u32,
+    ) -> Result<Vec<EncodedBlock>, Error> {
+        let padded_len = Self::padded_len(payload_len as usize, level);
+        let block_count = padded_len / Self::payload_block_size(level);
+        let encoded_block_size = Self::encoded_block_size(level);
+        let expected_len = block_count * encoded_block_size;
+
+        if bytes.len() != expected_len {
+            return Err(Error::InvalidFrameFormat);
+        }
+
+        let mut blocks = Vec::with_capacity(block_count);
+        for chunk in bytes.chunks_exact(encoded_block_size) {
+            let block = match level {
+                ProtectionLevel::High => {
+                    EncodedBlock::High(u16::from_le_bytes(chunk.try_into().unwrap()))
+                }
+                ProtectionLevel::Medium => {
+                    EncodedBlock::Medium(u64::from_le_bytes(chunk.try_into().unwrap()))
+                }
+                ProtectionLevel::Low => {
+                    EncodedBlock::Low(u128::from_le_bytes(chunk.try_into().unwrap()))
+                }
+            };
+            blocks.push(block);
+        }
+
+        Ok(blocks)
+    }
+
+    /// 新しい`StorageFrame`を作成します。
+    pub fn new(payload: Vec<u8>, sequence: u64, level: ProtectionLevel) -> Self {
+        let meta = MetaData::new(sequence, level, payload.len() as u32);
+        Self { meta, payload }
+    }
+
+    /// フレームをバイト列にシリアライズします。
+    /// この処理にはペイロードのパディング、ECCエンコード、bincodeシリアライズ、CRC計算が含まれます。
+    pub fn to_bytes(&self) -> Result<Vec<u8>, Error> {
+        // 1. ペイロードを保護レベルに応じてパディング
+        let padded_payload = Self::pad_payload(&self.payload, self.meta.level);
+
+        // 2. ECCブロックにエンコード
+        let encoded_blocks = ecc::encode(&padded_payload, self.meta.level)?;
+
+        // 3. 固定長バイナリへシリアライズ
+        let encoded_payload_bytes = Self::encode_blocks_to_bytes(&encoded_blocks, self.meta.level)?;
+
+        // 4. ヘッダーを生成
+        let primary_header = self.meta.encode();
+        let secondary_header = primary_header; // ミラー
+
+        // 5. CRCを計算し、フッターを生成
+        let crc = Self::checksum_content(&self.meta, &self.payload);
+        let footer = Footer::new(crc, self.meta.sequence);
+
+        // 6. 全てを結合して最終的なバイト列を返す
+        let mut final_bytes =
+            Vec::with_capacity(HEADERS_SIZE + encoded_payload_bytes.len() + FOOTER_SIZE);
+        final_bytes.extend_from_slice(primary_header.as_bytes());
+        final_bytes.extend_from_slice(secondary_header.as_bytes());
+        final_bytes.extend_from_slice(&encoded_payload_bytes);
+        final_bytes.extend_from_slice(&footer.to_bytes());
+
+        Ok(final_bytes)
+    }
+
+    /// バイト列から`StorageFrame`を復元します。
+    /// ヘッダーの修復、CRCチェック、ペイロードのデコードと修復を試みます。
+    pub fn recover(bytes: &[u8]) -> Result<Self, Error> {
+        // 1. 最低限の長さをチェック
+        if bytes.len() < MIN_FRAME_SIZE {
+            return Err(Error::FrameTooShort);
+        }
+
+        // 2. ヘッダーを復元
+        let primary_header_bytes: &[u8; PRIMARY_HEADER_SIZE] = &bytes
+            [PRIMARY_HEADER_OFFSET..SECONDARY_HEADER_OFFSET]
+            .try_into()
+            .unwrap();
+        let secondary_header_bytes: &[u8; SECONDARY_HEADER_SIZE] = &bytes
+            [SECONDARY_HEADER_OFFSET..HEADERS_SIZE]
+            .try_into()
+            .unwrap();
+
+        let meta = MetaDataHeader::from_bytes(primary_header_bytes)
+            .decode()
+            .or_else(|| MetaDataHeader::from_bytes(secondary_header_bytes).decode())
+            .ok_or(Error::UnrecoverableHeader)?;
+
+        // 3. フッターを取得
+        let footer_bytes: &[u8; FOOTER_SIZE] =
+            bytes[bytes.len() - FOOTER_SIZE..].try_into().unwrap();
+        let footer = Footer::from_bytes(footer_bytes);
+
+        // 4. ペイロードをデコード
+        let encoded_payload_bytes = &bytes[HEADERS_SIZE..bytes.len() - FOOTER_SIZE];
+        let blocks =
+            Self::decode_blocks_from_bytes(encoded_payload_bytes, meta.level, meta.payload_len)?;
+        let decoded_padded_payload = ecc::decode(&blocks)?;
+
+        // 5. パディングを削除して元のペイロードを取得
+        if decoded_padded_payload.len() < meta.payload_len as usize {
+            return Err(Error::CrcMismatch);
+        }
+        let payload = decoded_padded_payload[..meta.payload_len as usize].to_vec();
+
+        // 6. 復元済みデータで最終整合性を検証
+        let calculated_crc = Self::checksum_content(&meta, &payload);
+        if footer.crc32 != calculated_crc || footer.sequence_check != meta.sequence as u32 {
+            return Err(Error::CrcMismatch);
+        }
+
+        Ok(StorageFrame { meta, payload })
+    }
+
+    /// ペイロードを保護レベルのブロックサイズに合わせてパディングします。
+    fn pad_payload(payload: &[u8], level: ProtectionLevel) -> Vec<u8> {
+        let block_size = Self::payload_block_size(level);
+
+        let remainder = payload.len() % block_size;
+        if remainder == 0 {
+            return payload.to_vec();
+        }
+
+        let padding_len = block_size - remainder;
+        let mut padded = Vec::with_capacity(payload.len() + padding_len);
+        padded.extend_from_slice(payload);
+        padded.resize(payload.len() + padding_len, 0); // 0でパディング
+        padded
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn test_frame_roundtrip() {
+        let payload = b"hello, robust world!".to_vec();
+        let frame = StorageFrame::new(payload, 123, ProtectionLevel::Medium);
+        let bytes = frame.to_bytes().unwrap();
+        let recovered_frame = StorageFrame::recover(&bytes).unwrap();
+
+        assert_eq!(frame, recovered_frame);
+    }
+
+    #[test]
+    fn test_recover_with_primary_header_corruption() {
+        let payload = b"some important data".to_vec();
+        let frame = StorageFrame::new(payload, 456, ProtectionLevel::Low);
+        let mut bytes = frame.to_bytes().unwrap();
+
+        // プライマリヘッダーを破壊 (2ビット反転)
+        bytes[5] ^= 0b11;
+
+        let recovered_frame = StorageFrame::recover(&bytes).unwrap();
+        assert_eq!(frame, recovered_frame);
+    }
+
+    #[test]
+    fn test_recover_with_payload_corruption() {
+        let payload: Vec<u8> = (0..128).collect();
+        let frame = StorageFrame::new(payload, 789, ProtectionLevel::High);
+        let mut bytes = frame.to_bytes().unwrap();
+
+        // ペイロード部分のどこか1ビットを反転
+        // ヘッダー(32B)とフッター(8B)以外
+        let payload_offset = HEADERS_SIZE + 10;
+        bytes[payload_offset] ^= 0b0001_0000;
+
+        let recovered_frame = StorageFrame::recover(&bytes).unwrap();
+        assert_eq!(frame, recovered_frame);
+    }
+
+    #[test]
+    fn test_crc_mismatch_detection() {
+        let payload = b"data that must be integral".to_vec();
+        let frame = StorageFrame::new(payload, 1, ProtectionLevel::Medium);
+        let mut bytes = frame.to_bytes().unwrap();
+
+        // フッター内のCRC値を改ざんして不一致を確実に発生させる
+        let crc_offset = bytes.len() - FOOTER_SIZE;
+        let current_crc = u32::from_le_bytes(bytes[crc_offset..crc_offset + 4].try_into().unwrap());
+        let tampered_crc = current_crc.wrapping_add(1);
+        bytes[crc_offset..crc_offset + 4].copy_from_slice(&tampered_crc.to_le_bytes());
+
+        let result = StorageFrame::recover(&bytes);
+        assert!(matches!(result, Err(Error::CrcMismatch)));
+    }
+
+    #[test]
+    fn test_unrecoverable_header_error() {
+        let payload = b"test".to_vec();
+        let frame = StorageFrame::new(payload, 2, ProtectionLevel::High);
+        let mut bytes = frame.to_bytes().unwrap();
+
+        // 両方のヘッダーを破壊
+        bytes[0] ^= 0xff;
+        bytes[1] ^= 0xff;
+        bytes[16] ^= 0xff;
+        bytes[17] ^= 0xff;
+
+        let result = StorageFrame::recover(&bytes);
+        assert!(matches!(result, Err(Error::UnrecoverableHeader)));
+    }
+
+    #[test]
+    fn test_padding_logic() {
+        // Medium (4-byte alignment)
+        let payload1 = vec![1, 2, 3];
+        let padded1 = StorageFrame::pad_payload(&payload1, ProtectionLevel::Medium);
+        assert_eq!(padded1.len(), 4);
+        assert_eq!(&padded1, &[1, 2, 3, 0]);
+
+        // Low (8-byte alignment)
+        let payload2 = vec![1, 2, 3, 4, 5];
+        let padded2 = StorageFrame::pad_payload(&payload2, ProtectionLevel::Low);
+        assert_eq!(padded2.len(), 8);
+        assert_eq!(&padded2, &[1, 2, 3, 4, 5, 0, 0, 0]);
+
+        // High (no padding needed)
+        let payload3 = vec![1, 2, 3];
+        let padded3 = StorageFrame::pad_payload(&payload3, ProtectionLevel::High);
+        assert_eq!(padded3.len(), 3);
+        assert_eq!(payload3, padded3);
+    }
+}

--- a/crates/healed-serde/src/lib.rs
+++ b/crates/healed-serde/src/lib.rs
@@ -1,0 +1,1 @@
+pub mod ecc;

--- a/crates/healed-serde/src/lib.rs
+++ b/crates/healed-serde/src/lib.rs
@@ -2,6 +2,7 @@ pub mod ecc;
 pub mod error;
 pub mod frame;
 pub mod metadata;
+pub mod vault;
 
 use serde::{Deserialize, Serialize};
 

--- a/crates/healed-serde/src/lib.rs
+++ b/crates/healed-serde/src/lib.rs
@@ -1,11 +1,14 @@
 pub mod ecc;
 pub mod error;
+pub mod frame;
 pub mod metadata;
+
+use serde::{Deserialize, Serialize};
 
 /// データ保護レベル。
 ///
 /// オーバーヘッドと保護性能のトレードオフを調整します。
-#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Serialize, Deserialize)]
 #[repr(u8)]
 pub enum ProtectionLevel {
     /// 8bitデータ + ECC (高密度保護)

--- a/crates/healed-serde/src/lib.rs
+++ b/crates/healed-serde/src/lib.rs
@@ -1,1 +1,30 @@
 pub mod ecc;
+pub mod error;
+pub mod metadata;
+
+/// データ保護レベル。
+///
+/// オーバーヘッドと保護性能のトレードオフを調整します。
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+#[repr(u8)]
+pub enum ProtectionLevel {
+    /// 8bitデータ + ECC (高密度保護)
+    High = 0,
+    /// 32bitデータ + ECC (バランス)
+    Medium = 1,
+    /// 64bitデータ + ECC (低オーバーヘッド)
+    Low = 2,
+}
+
+impl TryFrom<u8> for ProtectionLevel {
+    type Error = crate::error::Error;
+
+    fn try_from(value: u8) -> Result<Self, Self::Error> {
+        match value {
+            0 => Ok(ProtectionLevel::High),
+            1 => Ok(ProtectionLevel::Medium),
+            2 => Ok(ProtectionLevel::Low),
+            _ => Err(crate::error::Error::InvalidProtectionLevel),
+        }
+    }
+}

--- a/crates/healed-serde/src/metadata.rs
+++ b/crates/healed-serde/src/metadata.rs
@@ -1,0 +1,168 @@
+use crate::ProtectionLevel;
+use secded::{SecDed128, SecDedCodec};
+
+const HEADER_BYTES: usize = 16;
+const METADATA_PAYLOAD_BITS: usize = 120;
+const METADATA_CODE_BITS: u32 = 8;
+const HEADER_MAGIC: u16 = 0xA55A;
+
+fn metadata_codec() -> SecDed128 {
+    SecDed128::new(METADATA_PAYLOAD_BITS)
+}
+
+/// ヘッダーに格納されるメタデータ。
+///
+/// 永続化されるデータのバージョン（シーケンス番号）、保護レベル、
+/// およびペイロード長を保持します。
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub struct MetaData {
+    /// データのシーケンス番号。ローリングアップデートに使用される。
+    pub sequence: u64,
+    /// ECC保護レベル。
+    pub level: ProtectionLevel,
+    /// シリアライズされたペイロードの元の長さ。
+    pub payload_len: u32,
+}
+
+/// メタデータを格納する16バイトの固定長ヘッダー。
+///
+/// 内部データはSECDEDによって1ビットエラー訂正が可能です。
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub struct MetaDataHeader {
+    /// 16バイトのバイナリデータ。
+    /// secdedで保護された固定長ヘッダー。
+    data: [u8; HEADER_BYTES],
+}
+
+impl MetaData {
+    /// 新しいMetaDataインスタンスを作成します。
+    pub fn new(sequence: u64, level: ProtectionLevel, payload_len: u32) -> Self {
+        Self {
+            sequence,
+            level,
+            payload_len,
+        }
+    }
+
+    fn pack_payload(&self) -> u128 {
+        let sequence = self.sequence as u128;
+        let payload_len = (self.payload_len as u128) << 64;
+        let level = (self.level as u8 as u128) << 96;
+        let magic = (HEADER_MAGIC as u128) << 104;
+        sequence | payload_len | level | magic
+    }
+
+    /// MetaDataをSECDEDで保護された16バイトのMetaDataHeaderにエンコードします。
+    pub fn encode(&self) -> MetaDataHeader {
+        let payload = self.pack_payload();
+        let mut data = (payload << METADATA_CODE_BITS).to_be_bytes();
+        let secded = metadata_codec();
+        secded.encode(&mut data);
+        MetaDataHeader { data }
+    }
+}
+
+impl MetaDataHeader {
+    /// 16バイトのスライスからMetaDataHeaderを作成します。
+    pub fn from_bytes(bytes: &[u8; HEADER_BYTES]) -> Self {
+        Self { data: *bytes }
+    }
+
+    /// ヘッダーデータをデコードし、1ビットエラーを修正してMetaDataを復元します。
+    ///
+    /// # Returns
+    /// 修正不可能なエラーがある場合は `None` を返します。
+    pub fn decode(&self) -> Option<MetaData> {
+        let secded = metadata_codec();
+        let mut decoded = self.data;
+        if secded.decode(&mut decoded).is_err() {
+            return None;
+        }
+
+        let payload = u128::from_be_bytes(decoded) >> METADATA_CODE_BITS;
+        let sequence = payload as u64;
+        let payload_len = ((payload >> 64) & 0xFFFF_FFFF) as u32;
+        let level_u8 = ((payload >> 96) & 0xFF) as u8;
+        let magic = ((payload >> 104) & 0xFFFF) as u16;
+
+        if magic != HEADER_MAGIC {
+            return None;
+        }
+
+        let level = ProtectionLevel::try_from(level_u8).ok()?;
+
+        Some(MetaData {
+            sequence,
+            level,
+            payload_len,
+        })
+    }
+
+    /// ヘッダーの生バイトデータを返します。
+    pub fn as_bytes(&self) -> &[u8; HEADER_BYTES] {
+        &self.data
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn test_metadata_encode_decode_roundtrip() {
+        let original_meta = MetaData::new(123456789, ProtectionLevel::Medium, 1024);
+        let header = original_meta.encode();
+        let decoded_meta = header.decode().expect("デコードは成功するはず");
+
+        assert_eq!(original_meta, decoded_meta);
+    }
+
+    #[test]
+    fn test_metadata_decode_with_1bit_error_correction() {
+        let original_meta = MetaData::new(987654321, ProtectionLevel::High, 4096);
+        let header = original_meta.encode();
+
+        for bit in 0..(HEADER_BYTES * 8) {
+            let mut corrupted_bytes = *header.as_bytes();
+            corrupted_bytes[bit / 8] ^= 1 << (bit % 8);
+
+            let corrupted_header = MetaDataHeader::from_bytes(&corrupted_bytes);
+            let decoded_meta = corrupted_header
+                .decode()
+                .expect("1ビットエラーは訂正されてデコードが成功するはず");
+
+            assert_eq!(
+                original_meta, decoded_meta,
+                "bit {} の1ビット反転でメタデータが復元できませんでした",
+                bit
+            );
+        }
+    }
+
+    #[test]
+    fn test_metadata_decode_with_2bit_error_fails() {
+        let original_meta = MetaData::new(1, ProtectionLevel::Low, 128);
+        let header = original_meta.encode();
+
+        let mut found_uncorrectable = false;
+        for bit1 in 0..(HEADER_BYTES * 8) {
+            for bit2 in (bit1 + 1)..(HEADER_BYTES * 8) {
+                let mut corrupted_bytes = *header.as_bytes();
+                corrupted_bytes[bit1 / 8] ^= 1 << (bit1 % 8);
+                corrupted_bytes[bit2 / 8] ^= 1 << (bit2 % 8);
+
+                let corrupted_header = MetaDataHeader::from_bytes(&corrupted_bytes);
+                if corrupted_header.decode().is_none() {
+                    found_uncorrectable = true;
+                    break;
+                }
+            }
+
+            if found_uncorrectable {
+                break;
+            }
+        }
+
+        assert!(found_uncorrectable, "2ビットエラーを検出できるべき");
+    }
+}

--- a/crates/healed-serde/src/metadata.rs
+++ b/crates/healed-serde/src/metadata.rs
@@ -108,6 +108,7 @@ impl MetaDataHeader {
 mod tests {
     use super::*;
 
+    /// MetaDataのエンコード/デコード往復が無損失で成立することを検証。
     #[test]
     fn test_metadata_encode_decode_roundtrip() {
         let original_meta = MetaData::new(123456789, ProtectionLevel::Medium, 1024);
@@ -117,6 +118,7 @@ mod tests {
         assert_eq!(original_meta, decoded_meta);
     }
 
+    /// ヘッダー全ビットの1ビット反転に対して訂正復元できることを検証。
     #[test]
     fn test_metadata_decode_with_1bit_error_correction() {
         let original_meta = MetaData::new(987654321, ProtectionLevel::High, 4096);
@@ -139,6 +141,7 @@ mod tests {
         }
     }
 
+    /// 2ビット破損の組み合わせに対して復元不能ケースを検出できることを検証。
     #[test]
     fn test_metadata_decode_with_2bit_error_fails() {
         let original_meta = MetaData::new(1, ProtectionLevel::Low, 128);

--- a/crates/healed-serde/src/vault.rs
+++ b/crates/healed-serde/src/vault.rs
@@ -114,17 +114,17 @@ impl MemoryBackend {
         .into()
     }
 
-    fn slot_ref<'a>(
-        slots: &'a [Option<Vec<u8>>],
+    fn slot_ref(
+        slots: &[Option<Vec<u8>>],
         index: usize,
-    ) -> Result<&'a Option<Vec<u8>>, Error> {
+    ) -> Result<&Option<Vec<u8>>, Error> {
         slots.get(index).ok_or_else(|| Self::invalid_index(index))
     }
 
-    fn slot_mut<'a>(
-        slots: &'a mut [Option<Vec<u8>>],
+    fn slot_mut(
+        slots: &mut [Option<Vec<u8>>],
         index: usize,
-    ) -> Result<&'a mut Option<Vec<u8>>, Error> {
+    ) -> Result<&mut Option<Vec<u8>>, Error> {
         slots
             .get_mut(index)
             .ok_or_else(|| Self::invalid_index(index))

--- a/crates/healed-serde/src/vault.rs
+++ b/crates/healed-serde/src/vault.rs
@@ -1,0 +1,324 @@
+use crate::error::Error;
+use crate::frame::StorageFrame;
+use crate::metadata::MetaDataHeader;
+use crate::ProtectionLevel;
+use serde::{de::DeserializeOwned, Serialize};
+use std::fs::{self, File};
+use std::io::{Read, Write};
+use std::path::PathBuf;
+
+/// 3つのスロットを用いたローリングアップデートによる永続化ストレージ。
+///
+/// 書き込み時は最も古いスロットを上書きし、読み込み時は破損していない最新のスロットを選択します。
+pub struct ReliableVault<T> {
+    dir: PathBuf,
+    filename_base: String,
+    _phantom: std::marker::PhantomData<T>,
+}
+
+impl<T> ReliableVault<T>
+where
+    T: Serialize + DeserializeOwned,
+{
+    /// 新しいVaultを作成します。
+    ///
+    /// # Arguments
+    /// * `dir`: データファイルを保存するディレクトリ。
+    /// * `filename_base`: ファイル名のプレフィックス（例: "data" -> "data.0", "data.1", "data.2"）。
+    pub fn new(dir: impl Into<PathBuf>, filename_base: impl Into<String>) -> Self {
+        Self {
+            dir: dir.into(),
+            filename_base: filename_base.into(),
+            _phantom: std::marker::PhantomData,
+        }
+    }
+
+    fn slot_path(&self, index: usize) -> PathBuf {
+        self.dir.join(format!("{}.{}", self.filename_base, index))
+    }
+
+    /// 最新の有効なデータを読み込みます。
+    ///
+    /// 全てのスロットを確認し、破損していないデータの中で最も新しいシーケンス番号を持つものを返します。
+    pub fn load(&self) -> Result<T, Error> {
+        let mut candidates = Vec::new();
+
+        for i in 0..3 {
+            let path = self.slot_path(i);
+            if !path.exists() {
+                continue;
+            }
+
+            // ファイル読み込み
+            let bytes = match fs::read(&path) {
+                Ok(b) => b,
+                Err(_) => continue, // 読み込みエラー（権限など）はスキップ
+            };
+
+            // フレーム復元試行
+            match StorageFrame::recover(&bytes) {
+                Ok(frame) => {
+                    candidates.push(frame);
+                }
+                Err(_) => continue, // 破損データはスキップ
+            }
+        }
+
+        if candidates.is_empty() {
+            return Err(std::io::Error::new(
+                std::io::ErrorKind::NotFound,
+                "No valid data slots found",
+            )
+            .into());
+        }
+
+        // シーケンス番号で降順ソート (最新が先頭)
+        candidates.sort_by_key(|f| std::cmp::Reverse(f.meta.sequence));
+
+        // 最新のものをデシリアライズ
+        let latest = &candidates[0];
+        let data: T = bincode::deserialize(&latest.payload)?;
+
+        Ok(data)
+    }
+
+    /// データを保存します。
+    ///
+    /// 現在の最大シーケンス番号を確認し、最も古いスロット（次のシーケンス番号 % 3）を上書きします。
+    pub fn save(&self, data: &T, level: ProtectionLevel) -> Result<(), Error> {
+        // ディレクトリ作成
+        if !self.dir.exists() {
+            fs::create_dir_all(&self.dir)?;
+        }
+
+        // 次のシーケンス番号を決定するためにヘッダーをスキャン
+        let mut max_sequence = 0;
+        let mut found_any = false;
+
+        for i in 0..3 {
+            let path = self.slot_path(i);
+            if !path.exists() {
+                continue;
+            }
+
+            let mut file = match File::open(&path) {
+                Ok(f) => f,
+                Err(_) => continue,
+            };
+
+            // Primary(16B) + Secondary(16B) = 32B だけ読んで高速にチェック
+            let mut buf = [0u8; 32];
+            if file.read_exact(&mut buf).is_ok() {
+                // Primary Header check
+                let primary_bytes: [u8; 16] = buf[0..16].try_into().unwrap();
+                if let Some(meta) = MetaDataHeader::from_bytes(&primary_bytes).decode() {
+                    if meta.sequence > max_sequence {
+                        max_sequence = meta.sequence;
+                    }
+                    found_any = true;
+                    continue; // Primaryが生きていればSecondaryは見なくてよい
+                }
+
+                // Secondary Header check
+                let secondary_bytes: [u8; 16] = buf[16..32].try_into().unwrap();
+                if let Some(meta) = MetaDataHeader::from_bytes(&secondary_bytes).decode() {
+                    if meta.sequence > max_sequence {
+                        max_sequence = meta.sequence;
+                    }
+                    found_any = true;
+                }
+            }
+        }
+
+        let new_sequence = if found_any { max_sequence + 1 } else { 1 };
+        let target_slot = (new_sequence % 3) as usize;
+        let target_path = self.slot_path(target_slot);
+
+        // ペイロードのシリアライズ
+        let payload = bincode::serialize(data)?;
+
+        // フレーム作成
+        let frame = StorageFrame::new(payload, new_sequence, level);
+        let bytes = frame.to_bytes()?;
+
+        // 書き込み
+        let mut file = File::create(target_path)?;
+        file.write_all(&bytes)?;
+        file.sync_all()?; // ディスクへのフラッシュを保証
+
+        Ok(())
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use serde::Deserialize;
+    use std::path::Path;
+
+    #[derive(Serialize, Deserialize, Debug, PartialEq, Eq)]
+    struct TestData {
+        id: u32,
+        message: String,
+    }
+
+    fn corrupt_slot_footer_crc(path: &Path) {
+        let mut bytes = fs::read(path).unwrap();
+        let crc_offset = bytes.len() - 8;
+        bytes[crc_offset] ^= 0xFF;
+        fs::write(path, bytes).unwrap();
+    }
+
+    fn truncate_slot(path: &Path, size: usize) {
+        let mut bytes = fs::read(path).unwrap();
+        bytes.truncate(size);
+        fs::write(path, bytes).unwrap();
+    }
+
+    #[test]
+    fn test_vault_rotation_and_recovery() {
+        let dir = tempfile::tempdir().unwrap();
+        let vault = ReliableVault::<TestData>::new(dir.path(), "test");
+
+        // 1. 正常なローテーション (4回保存 -> seq 1, 2, 3, 4)
+        // slot mapping: 1->1, 2->2, 3->0, 4->1(overwrite)
+        for i in 1..=4 {
+            let data = TestData {
+                id: i,
+                message: format!("msg {}", i),
+            };
+            vault.save(&data, ProtectionLevel::Medium).unwrap();
+        }
+
+        let loaded = vault.load().unwrap();
+        assert_eq!(loaded.id, 4, "最新のデータ(id=4)が読み込まれるべき");
+
+        // 2. 最新データの破損 (slot 1, seq 4 を破壊)
+        let slot1 = dir.path().join("test.1");
+        corrupt_slot_footer_crc(&slot1);
+
+        // 3. 自動フォールバック (次に新しい seq 3 が読み込まれるべき)
+        let loaded_fallback = vault.load().unwrap();
+        assert_eq!(
+            loaded_fallback.id, 3,
+            "破損した最新データの代わりに一つ前のデータが読み込まれるべき"
+        );
+    }
+
+    #[test]
+    fn test_vault_recovery_with_two_corrupted_slots() {
+        let dir = tempfile::tempdir().unwrap();
+        let vault = ReliableVault::<TestData>::new(dir.path(), "test");
+
+        // seq: 1->slot1, 2->slot2, 3->slot0, 4->slot1, 5->slot2
+        // 最終状態: slot0=seq3, slot1=seq4, slot2=seq5
+        for i in 1..=5 {
+            let data = TestData {
+                id: i,
+                message: format!("msg {}", i),
+            };
+            vault.save(&data, ProtectionLevel::Medium).unwrap();
+        }
+
+        // 最新2スロットを破損させる
+        corrupt_slot_footer_crc(&dir.path().join("test.2")); // seq5
+        corrupt_slot_footer_crc(&dir.path().join("test.1")); // seq4
+
+        // 残存する有効なseq3へフォールバックできること
+        let loaded = vault.load().unwrap();
+        assert_eq!(loaded.id, 3);
+    }
+
+    #[test]
+    fn test_vault_load_fails_when_all_slots_corrupted() {
+        let dir = tempfile::tempdir().unwrap();
+        let vault = ReliableVault::<TestData>::new(dir.path(), "test");
+
+        for i in 1..=3 {
+            let data = TestData {
+                id: i,
+                message: format!("msg {}", i),
+            };
+            vault.save(&data, ProtectionLevel::Low).unwrap();
+        }
+
+        for slot in 0..3 {
+            corrupt_slot_footer_crc(&dir.path().join(format!("test.{}", slot)));
+        }
+
+        let result = vault.load();
+        assert!(matches!(
+            result,
+            Err(Error::Io(ref e)) if e.kind() == std::io::ErrorKind::NotFound
+        ));
+    }
+
+    #[test]
+    fn test_vault_recovery_with_truncated_latest_slot() {
+        let dir = tempfile::tempdir().unwrap();
+        let vault = ReliableVault::<TestData>::new(dir.path(), "test");
+
+        // seq: 1->slot1, 2->slot2, 3->slot0, 4->slot1
+        for i in 1..=4 {
+            let data = TestData {
+                id: i,
+                message: format!("msg {}", i),
+            };
+            vault.save(&data, ProtectionLevel::Medium).unwrap();
+        }
+
+        // 最新slot(seq4)を途中書き込み想定で短くする
+        truncate_slot(&dir.path().join("test.1"), 12);
+
+        // 有効な次点seq3にフォールバックできること
+        let loaded = vault.load().unwrap();
+        assert_eq!(loaded.id, 3);
+    }
+
+    #[test]
+    fn test_vault_load_fails_when_all_slots_truncated() {
+        let dir = tempfile::tempdir().unwrap();
+        let vault = ReliableVault::<TestData>::new(dir.path(), "test");
+
+        for i in 1..=3 {
+            let data = TestData {
+                id: i,
+                message: format!("msg {}", i),
+            };
+            vault.save(&data, ProtectionLevel::High).unwrap();
+        }
+
+        // 3スロットすべて途中書き込み相当の短い不完全ファイルにする
+        for slot in 0..3 {
+            truncate_slot(&dir.path().join(format!("test.{}", slot)), 8);
+        }
+
+        let result = vault.load();
+        assert!(matches!(
+            result,
+            Err(Error::Io(ref e)) if e.kind() == std::io::ErrorKind::NotFound
+        ));
+    }
+
+    #[test]
+    fn test_vault_recovery_with_header_only_latest_slot() {
+        let dir = tempfile::tempdir().unwrap();
+        let vault = ReliableVault::<TestData>::new(dir.path(), "test");
+
+        // seq: 1->slot1, 2->slot2, 3->slot0, 4->slot1
+        for i in 1..=4 {
+            let data = TestData {
+                id: i,
+                message: format!("msg {}", i),
+            };
+            vault.save(&data, ProtectionLevel::Medium).unwrap();
+        }
+
+        // 最新slot(seq4)をヘッダーのみ(Primary+Secondary=32B)に切り詰める
+        truncate_slot(&dir.path().join("test.1"), 32);
+
+        // 不完全ファイルを無視して、有効な次点seq3へフォールバックできること
+        let loaded = vault.load().unwrap();
+        assert_eq!(loaded.id, 3);
+    }
+}

--- a/crates/healed-serde/src/vault.rs
+++ b/crates/healed-serde/src/vault.rs
@@ -6,10 +6,174 @@ use serde::{de::DeserializeOwned, Serialize};
 use std::fs::{self, File};
 use std::io::{Read, Write};
 use std::path::PathBuf;
+use std::sync::{Arc, Mutex};
 
-/// 3つのスロットを用いたローリングアップデートによる永続化ストレージ。
+/// ストレージバックエンドの振る舞いを定義するトレイト。
+///
+/// これを実装することで、ファイルシステム以外のバックエンド（KVS、mmapなど）を
+/// `ReliableVault` で使用できます。
+pub trait StorageBackend {
+    /// 指定されたインデックスのスロットからデータをバイト列として読み込みます。
+    /// スロットが存在しない場合は `std::io::ErrorKind::NotFound` を含む `Error::Io` を返すべきです。
+    fn read_slot(&self, index: usize) -> Result<Vec<u8>, Error>;
+
+    /// 指定されたインデックスのスロットにデータを書き込みます。
+    fn write_slot(&self, index: usize, data: &[u8]) -> Result<(), Error>;
+
+    /// スロットの先頭から指定された長さのデータを読み込みます。
+    /// `save` 時のシーケンス番号スキャンを高速化するために使用されます。
+    fn read_header(&self, index: usize, len: usize) -> Result<Vec<u8>, Error>;
+
+    /// バックエンド（ディレクトリなど）が存在することを保証します。
+    fn ensure_backend_exists(&self) -> Result<(), Error>;
+}
+
+/// 標準のファイルシステムをバックエンドとして使用する実装。
+pub struct FileSystemBackend {
+    dir: PathBuf,
+    filename_base: String,
+}
+
+impl FileSystemBackend {
+    /// 新しい `FileSystemBackend` を作成します。
+    pub fn new(dir: impl Into<PathBuf>, filename_base: impl Into<String>) -> Self {
+        Self {
+            dir: dir.into(),
+            filename_base: filename_base.into(),
+        }
+    }
+
+    fn slot_path(&self, index: usize) -> PathBuf {
+        self.dir.join(format!("{}.{}", self.filename_base, index))
+    }
+}
+
+impl StorageBackend for FileSystemBackend {
+    fn read_slot(&self, index: usize) -> Result<Vec<u8>, Error> {
+        fs::read(self.slot_path(index)).map_err(Into::into)
+    }
+
+    fn write_slot(&self, index: usize, data: &[u8]) -> Result<(), Error> {
+        let mut file = File::create(self.slot_path(index))?;
+        file.write_all(data)?;
+        file.sync_all()?;
+        Ok(())
+    }
+
+    fn read_header(&self, index: usize, len: usize) -> Result<Vec<u8>, Error> {
+        let file = File::open(self.slot_path(index))?;
+        let mut buf = Vec::with_capacity(len);
+        file.take(len as u64).read_to_end(&mut buf)?;
+        Ok(buf)
+    }
+
+    fn ensure_backend_exists(&self) -> Result<(), Error> {
+        if !self.dir.exists() {
+            fs::create_dir_all(&self.dir)?;
+        }
+        Ok(())
+    }
+}
+
+/// メモリ領域のみを使用する `StorageBackend` 実装。
+///
+/// テスト用途や、プロセス寿命内だけの一時ストレージ用途を想定しています。
+#[derive(Debug, Clone)]
+pub struct MemoryBackend {
+    slots: Arc<Mutex<Vec<Option<Vec<u8>>>>>,
+}
+
+impl MemoryBackend {
+    /// 指定スロット数で新しい `MemoryBackend` を作成します。
+    pub fn new(num_slots: usize) -> Self {
+        assert!(num_slots > 0, "MemoryBackend requires at least 1 slot");
+        Self {
+            slots: Arc::new(Mutex::new(vec![None; num_slots])),
+        }
+    }
+
+    fn lock_slots(&self) -> Result<std::sync::MutexGuard<'_, Vec<Option<Vec<u8>>>>, Error> {
+        self.slots
+            .lock()
+            .map_err(|_| std::io::Error::other("MemoryBackend lock poisoned").into())
+    }
+
+    fn not_found(index: usize) -> Error {
+        std::io::Error::new(
+            std::io::ErrorKind::NotFound,
+            format!("Memory slot {index} not found"),
+        )
+        .into()
+    }
+
+    fn invalid_index(index: usize) -> Error {
+        std::io::Error::new(
+            std::io::ErrorKind::InvalidInput,
+            format!("Memory slot index {index} is out of bounds"),
+        )
+        .into()
+    }
+
+    fn slot_ref<'a>(
+        slots: &'a [Option<Vec<u8>>],
+        index: usize,
+    ) -> Result<&'a Option<Vec<u8>>, Error> {
+        slots.get(index).ok_or_else(|| Self::invalid_index(index))
+    }
+
+    fn slot_mut<'a>(
+        slots: &'a mut [Option<Vec<u8>>],
+        index: usize,
+    ) -> Result<&'a mut Option<Vec<u8>>, Error> {
+        slots
+            .get_mut(index)
+            .ok_or_else(|| Self::invalid_index(index))
+    }
+
+    #[cfg(test)]
+    fn mutate_slot<F>(&self, index: usize, mutator: F) -> Result<(), Error>
+    where
+        F: FnOnce(&mut Vec<u8>),
+    {
+        let mut slots = self.lock_slots()?;
+        let slot = Self::slot_mut(&mut slots, index)?;
+        let data = slot.as_mut().ok_or_else(|| Self::not_found(index))?;
+        mutator(data);
+        Ok(())
+    }
+}
+
+impl StorageBackend for MemoryBackend {
+    fn read_slot(&self, index: usize) -> Result<Vec<u8>, Error> {
+        let slots = self.lock_slots()?;
+        let slot = Self::slot_ref(&slots, index)?;
+        slot.clone().ok_or_else(|| Self::not_found(index))
+    }
+
+    fn write_slot(&self, index: usize, data: &[u8]) -> Result<(), Error> {
+        let mut slots = self.lock_slots()?;
+        let slot = Self::slot_mut(&mut slots, index)?;
+        *slot = Some(data.to_vec());
+        Ok(())
+    }
+
+    fn read_header(&self, index: usize, len: usize) -> Result<Vec<u8>, Error> {
+        let mut data = self.read_slot(index)?;
+        if data.len() > len {
+            data.truncate(len);
+        }
+        Ok(data)
+    }
+
+    fn ensure_backend_exists(&self) -> Result<(), Error> {
+        Ok(())
+    }
+}
+
+/// 複数のスロットを用いたローリングアップデートによる永続化ストレージ。
 ///
 /// 書き込み時は最も古いスロットを上書きし、読み込み時は破損していない最新のスロットを選択します。
+/// ストレージバックエンドは `StorageBackend` トレイトを介して抽象化されています。
 ///
 /// # Examples
 ///
@@ -24,38 +188,47 @@ use std::path::PathBuf;
 ///     name: String,
 /// }
 ///
-/// let vault = ReliableVault::new("./data", "config");
+/// // ファイルシステムをバックエンドとして使用する例
+/// let vault = ReliableVault::<_>::new_with_fs("./data", "config");
 ///
 /// let config = Config { version: 1, name: "device-001".to_string() };
 /// vault.save(&config, ProtectionLevel::Medium).unwrap();
 ///
 /// let loaded: Config = vault.load().unwrap();
 /// ```
-pub struct ReliableVault<T> {
-    dir: PathBuf,
-    filename_base: String,
+pub struct ReliableVault<T, B: StorageBackend = FileSystemBackend> {
+    backend: B,
+    num_slots: usize,
     _phantom: std::marker::PhantomData<T>,
 }
 
-impl<T> ReliableVault<T>
+impl<T> ReliableVault<T, FileSystemBackend>
 where
     T: Serialize + DeserializeOwned,
 {
-    /// 新しいVaultを作成します。
+    /// ファイルシステムをバックエンドとして使用する新しいVaultを3スロットで作成します。
     ///
     /// # Arguments
     /// * `dir`: データファイルを保存するディレクトリ。
     /// * `filename_base`: ファイル名のプレフィックス（例: "data" -> "data.0", "data.1", "data.2"）。
-    pub fn new(dir: impl Into<PathBuf>, filename_base: impl Into<String>) -> Self {
+    pub fn new_with_fs(dir: impl Into<PathBuf>, filename_base: impl Into<String>) -> Self {
+        let backend = FileSystemBackend::new(dir, filename_base);
+        Self::new(backend, 3)
+    }
+}
+
+impl<T, B: StorageBackend> ReliableVault<T, B>
+where
+    T: Serialize + DeserializeOwned,
+{
+    /// 指定されたバックエンドとスロット数で新しいVaultを作成します。
+    pub fn new(backend: B, num_slots: usize) -> Self {
+        assert!(num_slots >= 3, "ReliableVault requires at least 3 slots");
         Self {
-            dir: dir.into(),
-            filename_base: filename_base.into(),
+            backend,
+            num_slots,
             _phantom: std::marker::PhantomData,
         }
-    }
-
-    fn slot_path(&self, index: usize) -> PathBuf {
-        self.dir.join(format!("{}.{}", self.filename_base, index))
     }
 
     /// 最新の有効なデータを読み込みます。
@@ -64,16 +237,11 @@ where
     pub fn load(&self) -> Result<T, Error> {
         let mut candidates = Vec::new();
 
-        for i in 0..3 {
-            let path = self.slot_path(i);
-            if !path.exists() {
-                continue;
-            }
-
-            // ファイル読み込み
-            let bytes = match fs::read(&path) {
+        for i in 0..self.num_slots {
+            let bytes = match self.backend.read_slot(i) {
                 Ok(b) => b,
-                Err(_) => continue, // 読み込みエラー（権限など）はスキップ
+                Err(Error::Io(e)) if e.kind() == std::io::ErrorKind::NotFound => continue,
+                Err(_) => continue, // その他の読み込みエラーはスキップ
             };
 
             // フレーム復元試行
@@ -105,31 +273,20 @@ where
 
     /// データを保存します。
     ///
-    /// 現在の最大シーケンス番号を確認し、最も古いスロット（次のシーケンス番号 % 3）を上書きします。
+    /// 現在の最大シーケンス番号を確認し、最も古いスロット（次のシーケンス番号 % スロット数）を上書きします。
     pub fn save(&self, data: &T, level: ProtectionLevel) -> Result<(), Error> {
-        // ディレクトリ作成
-        if !self.dir.exists() {
-            fs::create_dir_all(&self.dir)?;
-        }
+        self.backend.ensure_backend_exists()?;
 
         // 次のシーケンス番号を決定するためにヘッダーをスキャン
         let mut max_sequence = 0;
         let mut found_any = false;
 
-        for i in 0..3 {
-            let path = self.slot_path(i);
-            if !path.exists() {
-                continue;
-            }
+        for i in 0..self.num_slots {
+            if let Ok(buf) = self.backend.read_header(i, 32) {
+                if buf.len() != 32 {
+                    continue;
+                }
 
-            let mut file = match File::open(&path) {
-                Ok(f) => f,
-                Err(_) => continue,
-            };
-
-            // Primary(16B) + Secondary(16B) = 32B だけ読んで高速にチェック
-            let mut buf = [0u8; 32];
-            if file.read_exact(&mut buf).is_ok() {
                 // Primary Header check
                 let primary_bytes: [u8; 16] = buf[0..16].try_into().unwrap();
                 if let Some(meta) = MetaDataHeader::from_bytes(&primary_bytes).decode() {
@@ -152,8 +309,7 @@ where
         }
 
         let new_sequence = if found_any { max_sequence + 1 } else { 1 };
-        let target_slot = (new_sequence % 3) as usize;
-        let target_path = self.slot_path(target_slot);
+        let target_slot = (new_sequence as usize) % self.num_slots;
 
         // ペイロードのシリアライズ
         let payload = bincode::serialize(data)?;
@@ -162,12 +318,7 @@ where
         let frame = StorageFrame::new(payload, new_sequence, level);
         let bytes = frame.to_bytes()?;
 
-        // 書き込み
-        let mut file = File::create(target_path)?;
-        file.write_all(&bytes)?;
-        file.sync_all()?; // ディスクへのフラッシュを保証
-
-        Ok(())
+        self.backend.write_slot(target_slot, &bytes)
     }
 }
 
@@ -192,6 +343,7 @@ mod tests {
         payload: String,
     }
 
+    /// ストレステストで注入する故障シナリオ。
     #[derive(Debug, Clone, Copy)]
     enum StressScenario {
         LatestFooterCrcCorrupt,
@@ -204,6 +356,7 @@ mod tests {
         AllHeaderOnly,
     }
 
+    /// シナリオ実行後に期待される読み出し結果。
     #[derive(Debug, Clone, Copy)]
     enum ExpectedOutcome {
         LoadedId(u32),
@@ -240,10 +393,157 @@ mod tests {
         }
     }
 
+    /// MemoryBackendの基本I/O (read/write/read_header) と NotFound を検証。
+    #[test]
+    fn test_memory_backend_read_write_and_header() {
+        let backend = MemoryBackend::new(3);
+        backend.ensure_backend_exists().unwrap();
+
+        let payload = vec![1u8, 2, 3, 4, 5];
+        backend.write_slot(1, &payload).unwrap();
+
+        let full = backend.read_slot(1).unwrap();
+        assert_eq!(full, payload);
+
+        let header = backend.read_header(1, 3).unwrap();
+        assert_eq!(header, vec![1u8, 2, 3]);
+
+        assert!(matches!(
+            backend.read_slot(0),
+            Err(Error::Io(ref e)) if e.kind() == std::io::ErrorKind::NotFound
+        ));
+    }
+
+    /// MemoryBackendの境界外インデックスが InvalidInput として扱われることを検証。
+    #[test]
+    fn test_memory_backend_boundary_invalid_index() {
+        let backend = MemoryBackend::new(3);
+
+        assert!(matches!(
+            backend.read_slot(3),
+            Err(Error::Io(ref e)) if e.kind() == std::io::ErrorKind::InvalidInput
+        ));
+        assert!(matches!(
+            backend.read_header(99, 8),
+            Err(Error::Io(ref e)) if e.kind() == std::io::ErrorKind::InvalidInput
+        ));
+        assert!(matches!(
+            backend.write_slot(10, &[1, 2, 3]),
+            Err(Error::Io(ref e)) if e.kind() == std::io::ErrorKind::InvalidInput
+        ));
+    }
+
+    /// read_header の長さ0指定で空データが返ることを検証。
+    #[test]
+    fn test_memory_backend_boundary_zero_header_len() {
+        let backend = MemoryBackend::new(3);
+        backend.write_slot(0, &[1, 2, 3, 4]).unwrap();
+
+        let header = backend.read_header(0, 0).unwrap();
+        assert!(header.is_empty());
+    }
+
+    /// スロット数0のMemoryBackend生成は不正なためpanicすることを検証。
+    #[test]
+    #[should_panic(expected = "MemoryBackend requires at least 1 slot")]
+    fn test_memory_backend_new_panics_with_zero_slots() {
+        let _ = MemoryBackend::new(0);
+    }
+
+    /// ReliableVaultは3スロット以上前提のため、2スロット指定でpanicすることを検証。
+    #[test]
+    #[should_panic(expected = "ReliableVault requires at least 3 slots")]
+    fn test_vault_new_panics_when_slots_less_than_three() {
+        let backend = MemoryBackend::new(2);
+        let _ = ReliableVault::<TestData, _>::new(backend, 2);
+    }
+
+    /// MemoryBackend上でsave/loadの往復が成立することを検証。
+    #[test]
+    fn test_vault_with_memory_backend_roundtrip() {
+        let backend = MemoryBackend::new(3);
+        let vault = ReliableVault::<TestData, _>::new(backend, 3);
+
+        for i in 1..=4 {
+            let data = TestData {
+                id: i,
+                message: format!("msg {}", i),
+            };
+            vault.save(&data, ProtectionLevel::Medium).unwrap();
+        }
+
+        let loaded = vault.load().unwrap();
+        assert_eq!(loaded.id, 4);
+    }
+
+    /// MemoryBackend上で最新スロット破損時に次点スロットへフォールバックできることを検証。
+    #[test]
+    fn test_vault_with_memory_backend_fallback_after_corruption() {
+        let backend = MemoryBackend::new(3);
+        let vault = ReliableVault::<TestData, _>::new(backend.clone(), 3);
+
+        // seq: 1->slot1, 2->slot2, 3->slot0, 4->slot1
+        for i in 1..=4 {
+            let data = TestData {
+                id: i,
+                message: format!("msg {}", i),
+            };
+            vault.save(&data, ProtectionLevel::High).unwrap();
+        }
+
+        backend
+            .mutate_slot(1, |bytes| {
+                let crc_pos = bytes.len() - 8;
+                bytes[crc_pos] ^= 0xFF;
+            })
+            .unwrap();
+
+        let loaded = vault.load().unwrap();
+        assert_eq!(loaded.id, 3);
+    }
+
+    /// 5スロット運用時のローテーション境界と複数スロット破損後のフォールバックを検証。
+    #[test]
+    fn test_vault_with_memory_backend_boundary_rotation_five_slots() {
+        let backend = MemoryBackend::new(5);
+        let vault = ReliableVault::<TestData, _>::new(backend.clone(), 5);
+
+        // seq1..7 を保存して、5スロット循環の境界を跨ぐ
+        for i in 1..=7 {
+            let data = TestData {
+                id: i,
+                message: format!("msg {}", i),
+            };
+            vault.save(&data, ProtectionLevel::Medium).unwrap();
+        }
+
+        // 最新は seq7
+        let loaded_latest = vault.load().unwrap();
+        assert_eq!(loaded_latest.id, 7);
+
+        // seq7(slot2) と seq6(slot1) を壊すと次点は seq5(slot0)
+        backend
+            .mutate_slot(2, |bytes| {
+                let crc_pos = bytes.len() - 8;
+                bytes[crc_pos] ^= 0xFF;
+            })
+            .unwrap();
+        backend
+            .mutate_slot(1, |bytes| {
+                let crc_pos = bytes.len() - 8;
+                bytes[crc_pos] ^= 0xFF;
+            })
+            .unwrap();
+
+        let loaded_fallback = vault.load().unwrap();
+        assert_eq!(loaded_fallback.id, 5);
+    }
+
+    /// 最新スロット破損時に1世代前へフォールバックできることを検証。
     #[test]
     fn test_vault_rotation_and_recovery() {
         let dir = tempfile::tempdir().unwrap();
-        let vault = ReliableVault::<TestData>::new(dir.path(), "test");
+        let vault = ReliableVault::<TestData>::new_with_fs(dir.path(), "test");
 
         // 1. 正常なローテーション (4回保存 -> seq 1, 2, 3, 4)
         // slot mapping: 1->1, 2->2, 3->0, 4->1(overwrite)
@@ -260,7 +560,10 @@ mod tests {
 
         // 2. 最新データの破損 (slot 1, seq 4 を破壊)
         let slot1 = dir.path().join("test.1");
-        corrupt_slot_footer_crc(&slot1);
+        let mut bytes = fs::read(&slot1).unwrap();
+        let crc_pos = bytes.len() - 8;
+        bytes[crc_pos] ^= 0xFF; // CRCを破壊
+        fs::write(&slot1, bytes).unwrap();
 
         // 3. 自動フォールバック (次に新しい seq 3 が読み込まれるべき)
         let loaded_fallback = vault.load().unwrap();
@@ -270,10 +573,11 @@ mod tests {
         );
     }
 
+    /// 最新2スロット破損時にさらに古い健全スロットへフォールバックできることを検証。
     #[test]
     fn test_vault_recovery_with_two_corrupted_slots() {
         let dir = tempfile::tempdir().unwrap();
-        let vault = ReliableVault::<TestData>::new(dir.path(), "test");
+        let vault = ReliableVault::<TestData>::new_with_fs(dir.path(), "test");
 
         // seq: 1->slot1, 2->slot2, 3->slot0, 4->slot1, 5->slot2
         // 最終状態: slot0=seq3, slot1=seq4, slot2=seq5
@@ -294,10 +598,11 @@ mod tests {
         assert_eq!(loaded.id, 3);
     }
 
+    /// 全スロット破損時にNotFound相当エラーとなることを検証。
     #[test]
     fn test_vault_load_fails_when_all_slots_corrupted() {
         let dir = tempfile::tempdir().unwrap();
-        let vault = ReliableVault::<TestData>::new(dir.path(), "test");
+        let vault = ReliableVault::<TestData>::new_with_fs(dir.path(), "test");
 
         for i in 1..=3 {
             let data = TestData {
@@ -314,10 +619,11 @@ mod tests {
         assert_not_found(vault.load());
     }
 
+    /// 最新スロットが途中書き込み（truncate）でも次点へフォールバックできることを検証。
     #[test]
     fn test_vault_recovery_with_truncated_latest_slot() {
         let dir = tempfile::tempdir().unwrap();
-        let vault = ReliableVault::<TestData>::new(dir.path(), "test");
+        let vault = ReliableVault::<TestData>::new_with_fs(dir.path(), "test");
 
         // seq: 1->slot1, 2->slot2, 3->slot0, 4->slot1
         for i in 1..=4 {
@@ -336,10 +642,11 @@ mod tests {
         assert_eq!(loaded.id, 3);
     }
 
+    /// 全スロットが途中書き込み状態（truncate）の場合にNotFoundとなることを検証。
     #[test]
     fn test_vault_load_fails_when_all_slots_truncated() {
         let dir = tempfile::tempdir().unwrap();
-        let vault = ReliableVault::<TestData>::new(dir.path(), "test");
+        let vault = ReliableVault::<TestData>::new_with_fs(dir.path(), "test");
 
         for i in 1..=3 {
             let data = TestData {
@@ -357,10 +664,11 @@ mod tests {
         assert_not_found(vault.load());
     }
 
+    /// 最新スロットがヘッダーのみ（32B）でも次点へフォールバックできることを検証。
     #[test]
     fn test_vault_recovery_with_header_only_latest_slot() {
         let dir = tempfile::tempdir().unwrap();
-        let vault = ReliableVault::<TestData>::new(dir.path(), "test");
+        let vault = ReliableVault::<TestData>::new_with_fs(dir.path(), "test");
 
         // seq: 1->slot1, 2->slot2, 3->slot0, 4->slot1
         for i in 1..=4 {
@@ -379,6 +687,7 @@ mod tests {
         assert_eq!(loaded.id, 3);
     }
 
+    /// 代表的な破損シナリオを列挙し、期待結果（復旧 or NotFound）を網羅的に検証。
     #[test]
     fn test_vault_stress_cases_enumerated() {
         let cases = [
@@ -426,7 +735,7 @@ mod tests {
 
         for (name, scenario, expected) in cases {
             let dir = tempfile::tempdir().unwrap();
-            let vault = ReliableVault::<TestData>::new(dir.path(), "stress");
+            let vault = ReliableVault::<TestData>::new_with_fs(dir.path(), "stress");
 
             for id in 1..=5 {
                 let data = TestData {
@@ -490,6 +799,7 @@ mod tests {
         }
     }
 
+    /// JSONシリアライズのサイズ・復元整合性を small/medium/large ケースで検証。
     #[test]
     fn test_json_serialize_cases() {
         let cases = [

--- a/crates/healed-serde/src/vault.rs
+++ b/crates/healed-serde/src/vault.rs
@@ -162,6 +162,33 @@ mod tests {
         message: String,
     }
 
+    #[derive(Serialize, Deserialize, Debug, PartialEq, Eq)]
+    struct JsonCaseData {
+        id: u64,
+        name: String,
+        tags: Vec<String>,
+        values: Vec<u64>,
+        payload: String,
+    }
+
+    #[derive(Debug, Clone, Copy)]
+    enum StressScenario {
+        LatestFooterCrcCorrupt,
+        LatestTruncated,
+        LatestHeaderOnly,
+        TwoLatestFooterCrcCorrupt,
+        LatestHeaderOnlyAndSecondCorrupt,
+        AllFooterCrcCorrupt,
+        AllTruncated,
+        AllHeaderOnly,
+    }
+
+    #[derive(Debug, Clone, Copy)]
+    enum ExpectedOutcome {
+        LoadedId(u32),
+        NotFound,
+    }
+
     fn corrupt_slot_footer_crc(path: &Path) {
         let mut bytes = fs::read(path).unwrap();
         let crc_offset = bytes.len() - 8;
@@ -173,6 +200,23 @@ mod tests {
         let mut bytes = fs::read(path).unwrap();
         bytes.truncate(size);
         fs::write(path, bytes).unwrap();
+    }
+
+    fn assert_not_found(result: Result<TestData, Error>) {
+        assert!(matches!(
+            result,
+            Err(Error::Io(ref e)) if e.kind() == std::io::ErrorKind::NotFound
+        ));
+    }
+
+    fn build_json_case_data(id: u64, values_len: usize, payload_len: usize) -> JsonCaseData {
+        JsonCaseData {
+            id,
+            name: format!("case-{id}"),
+            tags: (0..8).map(|i| format!("tag-{id}-{i}")).collect(),
+            values: (0..values_len).map(|i| (id + i as u64) * 3).collect(),
+            payload: "x".repeat(payload_len),
+        }
     }
 
     #[test]
@@ -246,11 +290,7 @@ mod tests {
             corrupt_slot_footer_crc(&dir.path().join(format!("test.{}", slot)));
         }
 
-        let result = vault.load();
-        assert!(matches!(
-            result,
-            Err(Error::Io(ref e)) if e.kind() == std::io::ErrorKind::NotFound
-        ));
+        assert_not_found(vault.load());
     }
 
     #[test]
@@ -293,11 +333,7 @@ mod tests {
             truncate_slot(&dir.path().join(format!("test.{}", slot)), 8);
         }
 
-        let result = vault.load();
-        assert!(matches!(
-            result,
-            Err(Error::Io(ref e)) if e.kind() == std::io::ErrorKind::NotFound
-        ));
+        assert_not_found(vault.load());
     }
 
     #[test]
@@ -320,5 +356,145 @@ mod tests {
         // 不完全ファイルを無視して、有効な次点seq3へフォールバックできること
         let loaded = vault.load().unwrap();
         assert_eq!(loaded.id, 3);
+    }
+
+    #[test]
+    fn test_vault_stress_cases_enumerated() {
+        let cases = [
+            (
+                "latest_footer_crc_corrupt",
+                StressScenario::LatestFooterCrcCorrupt,
+                ExpectedOutcome::LoadedId(4),
+            ),
+            (
+                "latest_truncated",
+                StressScenario::LatestTruncated,
+                ExpectedOutcome::LoadedId(4),
+            ),
+            (
+                "latest_header_only",
+                StressScenario::LatestHeaderOnly,
+                ExpectedOutcome::LoadedId(4),
+            ),
+            (
+                "two_latest_footer_crc_corrupt",
+                StressScenario::TwoLatestFooterCrcCorrupt,
+                ExpectedOutcome::LoadedId(3),
+            ),
+            (
+                "latest_header_only_and_second_corrupt",
+                StressScenario::LatestHeaderOnlyAndSecondCorrupt,
+                ExpectedOutcome::LoadedId(3),
+            ),
+            (
+                "all_footer_crc_corrupt",
+                StressScenario::AllFooterCrcCorrupt,
+                ExpectedOutcome::NotFound,
+            ),
+            (
+                "all_truncated",
+                StressScenario::AllTruncated,
+                ExpectedOutcome::NotFound,
+            ),
+            (
+                "all_header_only",
+                StressScenario::AllHeaderOnly,
+                ExpectedOutcome::NotFound,
+            ),
+        ];
+
+        for (name, scenario, expected) in cases {
+            let dir = tempfile::tempdir().unwrap();
+            let vault = ReliableVault::<TestData>::new(dir.path(), "stress");
+
+            for id in 1..=5 {
+                let data = TestData {
+                    id,
+                    message: format!("msg {}", id),
+                };
+                vault.save(&data, ProtectionLevel::Medium).unwrap();
+            }
+
+            let slot0 = dir.path().join("stress.0"); // seq3
+            let slot1 = dir.path().join("stress.1"); // seq4
+            let slot2 = dir.path().join("stress.2"); // seq5
+
+            match scenario {
+                StressScenario::LatestFooterCrcCorrupt => corrupt_slot_footer_crc(&slot2),
+                StressScenario::LatestTruncated => truncate_slot(&slot2, 12),
+                StressScenario::LatestHeaderOnly => truncate_slot(&slot2, 32),
+                StressScenario::TwoLatestFooterCrcCorrupt => {
+                    corrupt_slot_footer_crc(&slot2);
+                    corrupt_slot_footer_crc(&slot1);
+                }
+                StressScenario::LatestHeaderOnlyAndSecondCorrupt => {
+                    truncate_slot(&slot2, 32);
+                    corrupt_slot_footer_crc(&slot1);
+                }
+                StressScenario::AllFooterCrcCorrupt => {
+                    corrupt_slot_footer_crc(&slot0);
+                    corrupt_slot_footer_crc(&slot1);
+                    corrupt_slot_footer_crc(&slot2);
+                }
+                StressScenario::AllTruncated => {
+                    truncate_slot(&slot0, 8);
+                    truncate_slot(&slot1, 8);
+                    truncate_slot(&slot2, 8);
+                }
+                StressScenario::AllHeaderOnly => {
+                    truncate_slot(&slot0, 32);
+                    truncate_slot(&slot1, 32);
+                    truncate_slot(&slot2, 32);
+                }
+            }
+
+            match expected {
+                ExpectedOutcome::LoadedId(expected_id) => {
+                    let loaded = vault
+                        .load()
+                        .unwrap_or_else(|e| panic!("{name}: load failed unexpectedly: {e}"));
+                    assert_eq!(loaded.id, expected_id, "{name}");
+                }
+                ExpectedOutcome::NotFound => {
+                    let result = vault.load();
+                    assert!(
+                        matches!(
+                            result,
+                            Err(Error::Io(ref e)) if e.kind() == std::io::ErrorKind::NotFound
+                        ),
+                        "{name}: expected NotFound, got {result:?}"
+                    );
+                }
+            }
+        }
+    }
+
+    #[test]
+    fn test_json_serialize_cases() {
+        let cases = [
+            ("small", build_json_case_data(1, 32, 256)),
+            ("medium", build_json_case_data(2, 512, 4 * 1024)),
+            ("large", build_json_case_data(3, 4096, 32 * 1024)),
+        ];
+
+        let mut prev_size = 0usize;
+        for (name, case) in cases {
+            let encoded = serde_json::to_vec(&case)
+                .unwrap_or_else(|e| panic!("{name}: failed to serialize JSON: {e}"));
+            assert!(
+                !encoded.is_empty(),
+                "{name}: serialized JSON should not be empty"
+            );
+            assert!(
+                encoded.len() > prev_size,
+                "{name}: serialized JSON size should grow with input size"
+            );
+
+            let decoded: JsonCaseData = serde_json::from_slice(&encoded)
+                .unwrap_or_else(|e| panic!("{name}: failed to deserialize JSON: {e}"));
+            assert_eq!(decoded, case, "{name}: JSON roundtrip mismatch");
+
+            prev_size = encoded.len();
+        }
     }
 }

--- a/crates/healed-serde/src/vault.rs
+++ b/crates/healed-serde/src/vault.rs
@@ -10,6 +10,27 @@ use std::path::PathBuf;
 /// 3つのスロットを用いたローリングアップデートによる永続化ストレージ。
 ///
 /// 書き込み時は最も古いスロットを上書きし、読み込み時は破損していない最新のスロットを選択します。
+///
+/// # Examples
+///
+/// ```no_run
+/// use healed_serde::vault::ReliableVault;
+/// use healed_serde::ProtectionLevel;
+/// use serde::{Serialize, Deserialize};
+///
+/// #[derive(Serialize, Deserialize, PartialEq, Debug)]
+/// struct Config {
+///     version: u32,
+///     name: String,
+/// }
+///
+/// let vault = ReliableVault::new("./data", "config");
+///
+/// let config = Config { version: 1, name: "device-001".to_string() };
+/// vault.save(&config, ProtectionLevel::Medium).unwrap();
+///
+/// let loaded: Config = vault.load().unwrap();
+/// ```
 pub struct ReliableVault<T> {
     dir: PathBuf,
     filename_base: String,


### PR DESCRIPTION
## What

耐障害性のあるシリアライズ、永続化ライブラリを作成

## Why

現実においてエラー発生は仕方がないが再起動しても直らないアプリケーションは困る。
永続化情報だけは確率的にエラーが起きたとしても、再起動を妨げない形式がほしいことがある。
普通のシリアライズと同じ使い方でビット異常からの復帰、履歴からの復帰をして表向き異常を起こさせない永続化を行う。